### PR TITLE
Custom Event Indexer API

### DIFF
--- a/src/domain/constants.ts
+++ b/src/domain/constants.ts
@@ -4,3 +4,4 @@ export const MYNODE_API_URL = "ws://localhost:8546";
 export const ETH_RPC_API_URL = "https://rpc.sepolia.org";
 export const L1_TAIKO_RPC_API_URL = "https://l1rpc.test.taiko.xyz";
 export const L2_TAIKO_RPC_API_URL = "https://rpc.test.taiko.xyz";
+export const EVENT_INDEXER_API_URL = "https://eventindexer.test.taiko.xyz";

--- a/src/pages/home/Home.svelte
+++ b/src/pages/home/Home.svelte
@@ -1,12 +1,4 @@
 <script lang="ts">
-
-/*
-<!--
-
--->
-*/
-
-
   import { onDestroy, onMount } from "svelte";
   import { queryPrometheus } from "../../utils/prometheus";
   import {
@@ -280,18 +272,7 @@
 
 
   const fetchAddressEvents = async () => {
-/*    // Fetch Amount Of blocks proposed/proven
-    let eventIndexerEventURL: string;
-    try {
-      if (nodeType === NodeTypes.Node) return;
-      eventIndexerEventURL = `https://eventindexer.test.taiko.xyz/eventByAddress?address=${L1Wallet}&event=${
-        nodeType === NodeTypes.Proposer
-          ? "BlockProposed"
-          : nodeType === NodeTypes.Prover
-          ? "BlockProven"
-          : ""
-      }`;
-*/
+    // Fetch Amount Of blocks proposed/proven
     let eventIndexerEventURL = CUSTOM_EVENT_INDEXER_API_URL;
     try {
     if(nodeType === NodeTypes.Node) return;
@@ -303,7 +284,6 @@
           : ""
       }`;
 
-
       const response = await fetch(eventIndexerEventURL);
       if (response.status === 200) {
         let addressEvent = await response.json();
@@ -311,11 +291,14 @@
           addressBlockProposed = addressEvent.count;
         else if (nodeType === NodeTypes.Prover)
           addressBlockProven = addressEvent.count;
+      fetchEventIndexerError = false;
       } else {
-        throw new Error("couldn't reach the eventindexer url");
+          fetchEventIndexerError = true;
+          throw new Error("couldn't reach the eventindexer url");
       }
     } catch (error) {
-      console.error(
+        fetchEventIndexerError = true;
+        console.error(
         `Error fetching address events for the ${nodeType} at ${eventIndexerEventURL}`,
         error
       );
@@ -907,7 +890,7 @@
 	    }}
 	    />
 	    <img
-	      src={fetchEthRPCError ? warningIcon : checkmarkIcon}
+	      src={fetchEventIndexerError ? warningIcon : checkmarkIcon}
 	      alt="icon"
 	      class="w-[30px] ml-2"
 />

--- a/src/pages/home/Home.svelte
+++ b/src/pages/home/Home.svelte
@@ -1,4 +1,12 @@
 <script lang="ts">
+
+/*
+<!--
+
+-->
+*/
+
+
   import { onDestroy, onMount } from "svelte";
   import { queryPrometheus } from "../../utils/prometheus";
   import {
@@ -40,6 +48,7 @@
     MYNODE_API_URL,
     PROMETHEUS_API_URL,
     SYSTEMINFO_API_URL,
+    EVENT_INDEXER_API_URL,
   } from "../../domain/constants";
 
   let myNode;
@@ -50,6 +59,7 @@
   let fetchPrometheusError = false;
   let fetchMyNodeError = false;
   let fetchEthRPCError = false;
+  let fetchEventIndexerError = false;
 
   // Syncing estimation
   let startNodeHeight;
@@ -71,6 +81,8 @@
     getLocalStorageItem("CUSTOM_PROMETHEUS_API_URL") || PROMETHEUS_API_URL;
   let CUSTOM_SYSTEMINFO_API_URL =
     getLocalStorageItem("CUSTOM_SYSTEMINFO_API_URL") || SYSTEMINFO_API_URL;
+  let CUSTOM_EVENT_INDEXER_API_URL =
+    getLocalStorageItem("CUSTOM_EVENT_INDEXER_API_URL") || EVENT_INDEXER_API_URL;
 
   // Initialize the web3 RPC connections with error handling to see if we have provided a valid RPC provider
   function initConnections() {
@@ -266,8 +278,9 @@
     }
   }
 
+
   const fetchAddressEvents = async () => {
-    // Fetch Amount Of blocks proposed/proven
+/*    // Fetch Amount Of blocks proposed/proven
     let eventIndexerEventURL: string;
     try {
       if (nodeType === NodeTypes.Node) return;
@@ -278,6 +291,19 @@
           ? "BlockProven"
           : ""
       }`;
+*/
+    let eventIndexerEventURL = CUSTOM_EVENT_INDEXER_API_URL;
+    try {
+    if(nodeType === NodeTypes.Node) return;
+      eventIndexerEventURL = eventIndexerEventURL + `/eventByAddress?address=${L1Wallet}&event=${
+          nodeType === NodeTypes.Proposer
+          ? "BlockProposed"
+          : nodeType === NodeTypes.Prover
+          ? "BlockProven"
+          : ""
+      }`;
+
+
       const response = await fetch(eventIndexerEventURL);
       if (response.status === 200) {
         let addressEvent = await response.json();
@@ -508,7 +534,8 @@
         fetchSystemInfoError ||
         fetchPrometheusError ||
         fetchMyNodeError ||
-        fetchEthRPCError
+        fetchEthRPCError ||
+	fetchEventIndexerError
           ? "animateConnections"
           : ""}
         alt="antenna icon"
@@ -860,6 +887,33 @@
           />
         </div>
       </div>
+
+      <div
+        class="flex sm:flex-row flex-col justify-between items-center font-bold"
+      >
+        Event Indexer:
+        <div class="ml-2 w-72 flex items-center">
+          <input
+            class="shadow appearance-none rounded w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline mb-1"
+            type="text"
+            bind:value={CUSTOM_EVENT_INDEXER_API_URL}
+	    placeholder={EVENT_INDEXER_API_URL}
+	    on:change={() => {
+	      setLocalStorageItem(
+	        "CUSTOM_EVENT_INDEXER_API_URL",
+		CUSTOM_EVENT_INDEXER_API_URL
+	      );
+	      initConnections();
+	    }}
+	    />
+	    <img
+	      src={fetchEthRPCError ? warningIcon : checkmarkIcon}
+	      alt="icon"
+	      class="w-[30px] ml-2"
+/>
+	</div>
+</div>
+
     </div>
   </DetailsModal>
 {/if}


### PR DESCRIPTION
Adds a new field for an Event Indexer in the Connections modal. 
Try https://eventindexer.l3test.taiko.xyz(L3 events) or maybe http://108.61.54.59:4101 (L2 events but it's missing a lot of data I think , need to fix it)
Default is still https://eventindexer.test.taiko.xyz
Regards,  Spach